### PR TITLE
Fixed fswatch check.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -106,7 +106,7 @@ final class Plugin implements HandlesArguments
     {
         exec('fswatch 2>&1', $output);
 
-        if (strpos(implode(' ', $output), 'command not found') === false) {
+        if (strpos(implode(' ', $output), 'not found') === false) {
             return;
         }
 


### PR DESCRIPTION
Contents of $output was:

```php
array (
  0 => 'sh: 1: fswatch: not found',
)
```

(in Laravel Sail container). Hence, all seemed fine, and the error and hint were not shown. However the loop exited after 1 run.

By the way, when issuing `fswatch` in the shell (bash), the output _did_ contain "command not found"...